### PR TITLE
Github pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - copilot/create-flutter-app-workflow
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -13,8 +16,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: "pages-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/GITHUB_PAGES_SETUP.md
+++ b/GITHUB_PAGES_SETUP.md
@@ -16,6 +16,7 @@ To enable deployment to GitHub Pages, the repository owner needs to complete the
 
 Once GitHub Pages is enabled:
 - The workflow will automatically deploy when changes are pushed to the `main` or `copilot/create-flutter-app-workflow` branch
+- The workflow will also trigger on pull requests targeting the `main` branch, allowing PR preview deployments
 - The app will be available at: https://liodene.github.io/Just-another-day/
 
 ## Workflow Details


### PR DESCRIPTION
Enable GitHub Pages deployment from pull requests to allow for preview environments.

This allows changes in pull requests to be deployed to GitHub Pages, providing a preview environment for easier review and testing before merging to `main`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b580d578-1377-43f2-a3a1-60d2ce39916f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b580d578-1377-43f2-a3a1-60d2ce39916f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

