### PR TITLE
Time system changes

### DIFF
--- a/lib/engine/activity_manager.dart
+++ b/lib/engine/activity_manager.dart
@@ -18,15 +18,19 @@ typedef ActivityProgressCallback = void Function(ActivityProgress? progress);
 typedef PlannedActivityCompletedCallback =
     void Function(PlannedActivity planned);
 
+/// Callback type for when the day expires (time reaches 24:00).
+typedef DayExpiredCallback = void Function(Map<StatType, double> dailyGains);
+
 /// Manages activity progression and integrates with the game loop.
 ///
 /// This class handles:
 /// - Starting and stopping activities
 /// - Tracking activity progress
-/// - Applying stat rewards on completion
+/// - Accumulating stat rewards (applied at day end)
 /// - Auto-repeating activities
 /// - Tracking in-game time and real time played
 /// - Activity planning and queue management
+/// - Day expiration handling
 class ActivityManager extends ChangeNotifier {
   /// Creates a new [ActivityManager].
   ActivityManager({
@@ -56,6 +60,12 @@ class ActivityManager extends ChangeNotifier {
   ActivityCompletedCallback? _onActivityCompleted;
   ActivityProgressCallback? _onProgressChanged;
   PlannedActivityCompletedCallback? _onPlannedActivityCompleted;
+  DayExpiredCallback? _onDayExpired;
+  bool _dayExpiredNotified = false;
+
+  /// Accumulated stat gains for the current day.
+  /// These are applied when the day is reset via [startNewDay].
+  final Map<StatType, double> _dailyGains = {};
 
   /// The activity planner for managing the activity queue.
   ActivityPlanner get planner => _planner;
@@ -92,6 +102,14 @@ class ActivityManager extends ChangeNotifier {
   set onPlannedActivityCompleted(PlannedActivityCompletedCallback? callback) {
     _onPlannedActivityCompleted = callback;
   }
+
+  /// Sets a callback for when the day expires (time reaches 24:00).
+  set onDayExpired(DayExpiredCallback? callback) {
+    _onDayExpired = callback;
+  }
+
+  /// Gets the accumulated stat gains for the current day.
+  Map<StatType, double> get dailyGains => Map.unmodifiable(_dailyGains);
 
   void _onPlannerChanged() {
     notifyListeners();
@@ -198,9 +216,35 @@ class ActivityManager extends ChangeNotifier {
   }
 
   void _onGameLoopTick(double deltaTimeMs) {
+    // Check if day just expired
+    if (gameTime.isExpired && !_dayExpiredNotified) {
+      _dayExpiredNotified = true;
+      // Stop current activity when day expires
+      if (_currentProgress != null) {
+        stopActivity(saveProgress: true);
+      }
+      _onDayExpired?.call(Map.from(_dailyGains));
+      notifyListeners();
+      return;
+    }
+
+    // Don't process activities if day is expired
+    if (gameTime.isExpired) {
+      return;
+    }
+
     // Only update game time when there's an active activity
     if (_currentProgress != null) {
       gameTime.update(deltaTimeMs);
+
+      // Check again if day just expired after time update
+      if (gameTime.isExpired) {
+        _dayExpiredNotified = true;
+        stopActivity(saveProgress: true);
+        _onDayExpired?.call(Map.from(_dailyGains));
+        notifyListeners();
+        return;
+      }
 
       // Convert milliseconds to seconds for activity progress
       final deltaTimeSec = deltaTimeMs / 1000.0;
@@ -358,16 +402,13 @@ class ActivityManager extends ChangeNotifier {
 
   /// Estimates the total in-game time for the current plan.
   ///
-  /// This takes into account:
-  /// - Difficulty increasing with each completion (1.10x per completion)
-  /// - Stats improving from activity rewards after each completion
+  /// Since stats are now applied at day end (not during the day), this
+  /// calculation only needs to account for difficulty increasing with each
+  /// completion (1.10x per completion), making it simpler and more accurate.
   double estimatePlanTime() {
     if (!_planner.hasPlannedActivities) return 0.0;
 
-    // Create simulated stats (copy of current stats)
-    final simStats = character.stats.copyWith();
-
-    // Track simulated completions per activity
+    // Track simulated completions per activity (difficulty increases)
     final simCompletions = Map<String, int>.from(character.activityCompletions);
 
     var totalTime = 0.0;
@@ -386,48 +427,23 @@ class ActivityManager extends ChangeNotifier {
           final remaining = (planned.targetValue - planned.completedValue)
               .toInt();
           for (var i = 0; i < remaining; i++) {
-            // Calculate duration with current simulated state
+            // Calculate duration with current difficulty
             final coefficient = _calculateCoefficient(
               simCompletions[activityId] ?? 0,
             );
             final duration = activity.calculateDuration(
-              simStats,
+              character.stats,
               difficultyCoefficient: coefficient,
             );
             totalTime += duration;
 
-            // Simulate completion: update stats and difficulty
-            _applySimulatedRewards(simStats, activity.rewards);
+            // Simulate completion: increase difficulty only
             simCompletions[activityId] = (simCompletions[activityId] ?? 0) + 1;
           }
 
         case PlanTargetType.inGameTime:
-          // For time-based targets, estimate how many completions will occur
-          // and account for stats evolution during that time
-          var remainingTime = planned.targetValue - planned.completedValue;
-          while (remainingTime > 0) {
-            final coefficient = _calculateCoefficient(
-              simCompletions[activityId] ?? 0,
-            );
-            final duration = activity.calculateDuration(
-              simStats,
-              difficultyCoefficient: coefficient,
-            );
-
-            if (duration >= remainingTime) {
-              // Partial completion - just add remaining time
-              totalTime += remainingTime;
-              break;
-            }
-
-            // Full completion within the time budget
-            totalTime += duration;
-            remainingTime -= duration;
-
-            // Simulate completion: update stats and difficulty
-            _applySimulatedRewards(simStats, activity.rewards);
-            simCompletions[activityId] = (simCompletions[activityId] ?? 0) + 1;
-          }
+          // For time-based targets, the time is simply the remaining target
+          totalTime += planned.targetValue - planned.completedValue;
 
         case PlanTargetType.unlimited:
           // Already handled above
@@ -448,21 +464,44 @@ class ActivityManager extends ChangeNotifier {
     return result;
   }
 
-  /// Applies rewards to simulated stats.
-  void _applySimulatedRewards(
-    CharacterStats stats,
-    Map<StatType, double> rewards,
-  ) {
-    for (final entry in rewards.entries) {
-      stats.addToStat(entry.key, entry.value);
-    }
-  }
-
   void _applyRewards(Activity activity, double multiplier) {
     for (final entry in activity.rewards.entries) {
       final amount = entry.value * multiplier;
-      character.stats.addToStat(entry.key, amount);
+      // Accumulate rewards instead of applying directly
+      _dailyGains[entry.key] = (_dailyGains[entry.key] ?? 0.0) + amount;
     }
+  }
+
+  /// Starts a new day, applying accumulated stat gains and resetting time.
+  ///
+  /// This should be called when the user dismisses the day end modal.
+  void startNewDay() {
+    // Apply accumulated stats to the character
+    for (final entry in _dailyGains.entries) {
+      character.stats.addToStat(entry.key, entry.value);
+    }
+
+    // Reset daily gains
+    _dailyGains.clear();
+
+    // Reset the day expired notification flag
+    _dayExpiredNotified = false;
+
+    // Start a new day in the game time
+    gameTime.startNewDay();
+
+    // Stop any current activity
+    if (_currentProgress != null) {
+      stopActivity(saveProgress: true);
+    }
+
+    notifyListeners();
+  }
+
+  /// Clears accumulated daily gains without applying them.
+  void clearDailyGains() {
+    _dailyGains.clear();
+    notifyListeners();
   }
 
   /// Disposes of the activity manager and cleans up resources.

--- a/lib/engine/activity_manager.dart
+++ b/lib/engine/activity_manager.dart
@@ -62,9 +62,9 @@ class ActivityManager extends ChangeNotifier {
   PlannedActivityCompletedCallback? _onPlannedActivityCompleted;
   DayExpiredCallback? _onDayExpired;
 
-  /// Accumulated stat gains for the current day.
-  /// These are applied when the day is reset via [startNewDay].
-  final Map<StatType, double> _dailyGains = {};
+  /// Completions per activity for the current day.
+  /// At day end, only completions above the character's record give stat gains.
+  final Map<String, int> _dailyCompletions = {};
 
   /// The activity planner for managing the activity queue.
   ActivityPlanner get planner => _planner;
@@ -107,8 +107,38 @@ class ActivityManager extends ChangeNotifier {
     _onDayExpired = callback;
   }
 
-  /// Gets the accumulated stat gains for the current day.
-  Map<StatType, double> get dailyGains => Map.unmodifiable(_dailyGains);
+  /// Gets the daily completions per activity.
+  Map<String, int> get dailyCompletions => Map.unmodifiable(_dailyCompletions);
+
+  /// Gets the expected stat gains for the current day.
+  ///
+  /// Only completions above the character's record count towards stat gains.
+  Map<StatType, double> get dailyGains {
+    final gains = <StatType, double>{};
+
+    for (final entry in _dailyCompletions.entries) {
+      final activityId = entry.key;
+      final completions = entry.value;
+      final record = character.getCompletionRecord(activityId);
+
+      // Only new levels above the record give stats
+      final newLevels = completions > record ? completions - record : 0;
+      if (newLevels > 0) {
+        // Find the activity to get its rewards
+        final activity = Activities.all.firstWhere(
+          (a) => a.id == activityId,
+          orElse: () => Activities.working,
+        );
+
+        for (final reward in activity.rewards.entries) {
+          gains[reward.key] =
+              (gains[reward.key] ?? 0.0) + reward.value * newLevels;
+        }
+      }
+    }
+
+    return Map.unmodifiable(gains);
+  }
 
   void _onPlannerChanged() {
     notifyListeners();
@@ -189,7 +219,8 @@ class ActivityManager extends ChangeNotifier {
     if (_currentProgress == null) return;
 
     if (grantPartialRewards && _currentProgress!.progress > 0) {
-      _applyRewards(_currentProgress!.activity, _currentProgress!.progress);
+      // Partial completions don't count towards daily stats in the new system
+      // (only full completions above record give stats)
     }
 
     // Save partial progress before stopping (unless granting rewards)
@@ -257,16 +288,16 @@ class ActivityManager extends ChangeNotifier {
     // Pause the game loop - no point running it while day is expired
     _gameLoop.pause();
 
-    // Notify listeners about day expiration
-    _onDayExpired?.call(Map.from(_dailyGains));
+    // Notify listeners about day expiration with computed gains
+    _onDayExpired?.call(dailyGains);
     notifyListeners();
   }
 
   void _onActivityComplete() {
     final activity = _currentProgress!.activity;
 
-    // Apply full rewards
-    _applyRewards(activity, 1.0);
+    // Record the completion for daily stats
+    _recordCompletion(activity, 1.0);
 
     // Increment this activity's completion count (increases its difficulty)
     character.addCompletion(activity.id);
@@ -458,25 +489,50 @@ class ActivityManager extends ChangeNotifier {
     return result;
   }
 
-  void _applyRewards(Activity activity, double multiplier) {
-    for (final entry in activity.rewards.entries) {
-      final amount = entry.value * multiplier;
-      // Accumulate rewards instead of applying directly
-      _dailyGains[entry.key] = (_dailyGains[entry.key] ?? 0.0) + amount;
+  /// Records a completion for tracking daily stats.
+  ///
+  /// Note: [multiplier] is ignored since stats are based on completion count,
+  /// not partial completions.
+  void _recordCompletion(Activity activity, double multiplier) {
+    // Only count full completions (multiplier == 1.0)
+    if (multiplier >= 1.0) {
+      _dailyCompletions[activity.id] =
+          (_dailyCompletions[activity.id] ?? 0) + 1;
     }
   }
 
-  /// Starts a new day, applying accumulated stat gains and resetting time.
+  /// Starts a new day, applying stat gains and resetting time.
   ///
+  /// Only completions above the character's record give stat gains.
   /// This should be called when the user dismisses the day end modal.
   void startNewDay() {
-    // Apply accumulated stats to the character
-    for (final entry in _dailyGains.entries) {
-      character.stats.addToStat(entry.key, entry.value);
+    // Calculate and apply stat gains based on new levels above records
+    for (final entry in _dailyCompletions.entries) {
+      final activityId = entry.key;
+      final completions = entry.value;
+
+      // Update record and get number of new levels
+      final newLevels = character.updateCompletionRecord(
+        activityId,
+        completions,
+      );
+
+      if (newLevels > 0) {
+        // Find the activity to get its rewards
+        final activity = Activities.all.firstWhere(
+          (a) => a.id == activityId,
+          orElse: () => Activities.working,
+        );
+
+        // Apply rewards for each new level
+        for (final reward in activity.rewards.entries) {
+          character.stats.addToStat(reward.key, reward.value * newLevels);
+        }
+      }
     }
 
-    // Reset daily gains
-    _dailyGains.clear();
+    // Reset daily completions
+    _dailyCompletions.clear();
 
     // Start a new day in the game time
     gameTime.startNewDay();
@@ -487,9 +543,9 @@ class ActivityManager extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Clears accumulated daily gains without applying them.
-  void clearDailyGains() {
-    _dailyGains.clear();
+  /// Clears daily completions without applying them.
+  void clearDailyCompletions() {
+    _dailyCompletions.clear();
     notifyListeners();
   }
 

--- a/lib/engine/activity_manager.dart
+++ b/lib/engine/activity_manager.dart
@@ -249,9 +249,9 @@ class ActivityManager extends ChangeNotifier {
 
   /// Handles the day expiration by stopping activities and pausing the loop.
   void _handleDayExpired() {
-    // Stop current activity
+    // Stop current activity without saving progress (day ended)
     if (_currentProgress != null) {
-      stopActivity(saveProgress: true);
+      stopActivity(saveProgress: false);
     }
 
     // Pause the game loop - no point running it while day is expired

--- a/lib/engine/activity_manager.dart
+++ b/lib/engine/activity_manager.dart
@@ -61,7 +61,6 @@ class ActivityManager extends ChangeNotifier {
   ActivityProgressCallback? _onProgressChanged;
   PlannedActivityCompletedCallback? _onPlannedActivityCompleted;
   DayExpiredCallback? _onDayExpired;
-  bool _dayExpiredNotified = false;
 
   /// Accumulated stat gains for the current day.
   /// These are applied when the day is reset via [startNewDay].
@@ -216,33 +215,13 @@ class ActivityManager extends ChangeNotifier {
   }
 
   void _onGameLoopTick(double deltaTimeMs) {
-    // Check if day just expired
-    if (gameTime.isExpired && !_dayExpiredNotified) {
-      _dayExpiredNotified = true;
-      // Stop current activity when day expires
-      if (_currentProgress != null) {
-        stopActivity(saveProgress: true);
-      }
-      _onDayExpired?.call(Map.from(_dailyGains));
-      notifyListeners();
-      return;
-    }
-
-    // Don't process activities if day is expired
-    if (gameTime.isExpired) {
-      return;
-    }
-
     // Only update game time when there's an active activity
     if (_currentProgress != null) {
       gameTime.update(deltaTimeMs);
 
-      // Check again if day just expired after time update
+      // Check if day just expired after time update
       if (gameTime.isExpired) {
-        _dayExpiredNotified = true;
-        stopActivity(saveProgress: true);
-        _onDayExpired?.call(Map.from(_dailyGains));
-        notifyListeners();
+        _handleDayExpired();
         return;
       }
 
@@ -265,6 +244,21 @@ class ActivityManager extends ChangeNotifier {
       }
     }
 
+    notifyListeners();
+  }
+
+  /// Handles the day expiration by stopping activities and pausing the loop.
+  void _handleDayExpired() {
+    // Stop current activity
+    if (_currentProgress != null) {
+      stopActivity(saveProgress: true);
+    }
+
+    // Pause the game loop - no point running it while day is expired
+    _gameLoop.pause();
+
+    // Notify listeners about day expiration
+    _onDayExpired?.call(Map.from(_dailyGains));
     notifyListeners();
   }
 
@@ -484,16 +478,11 @@ class ActivityManager extends ChangeNotifier {
     // Reset daily gains
     _dailyGains.clear();
 
-    // Reset the day expired notification flag
-    _dayExpiredNotified = false;
-
     // Start a new day in the game time
     gameTime.startNewDay();
 
-    // Stop any current activity
-    if (_currentProgress != null) {
-      stopActivity(saveProgress: true);
-    }
+    // Resume the game loop (it was paused when day expired)
+    _gameLoop.resume();
 
     notifyListeners();
   }

--- a/lib/engine/activity_manager.dart
+++ b/lib/engine/activity_manager.dart
@@ -534,6 +534,9 @@ class ActivityManager extends ChangeNotifier {
     // Reset daily completions
     _dailyCompletions.clear();
 
+    // Reset activity difficulty (completions used for difficulty coefficient)
+    character.resetCompletions();
+
     // Start a new day in the game time
     gameTime.startNewDay();
 

--- a/lib/engine/activity_manager.dart
+++ b/lib/engine/activity_manager.dart
@@ -62,10 +62,6 @@ class ActivityManager extends ChangeNotifier {
   PlannedActivityCompletedCallback? _onPlannedActivityCompleted;
   DayExpiredCallback? _onDayExpired;
 
-  /// Completions per activity for the current day.
-  /// At day end, only completions above the character's record give stat gains.
-  final Map<String, int> _dailyCompletions = {};
-
   /// The activity planner for managing the activity queue.
   ActivityPlanner get planner => _planner;
 
@@ -108,7 +104,8 @@ class ActivityManager extends ChangeNotifier {
   }
 
   /// Gets the daily completions per activity.
-  Map<String, int> get dailyCompletions => Map.unmodifiable(_dailyCompletions);
+  Map<String, int> get dailyCompletions =>
+      Map.unmodifiable(character.activityCompletions);
 
   /// Gets the expected stat gains for the current day.
   ///
@@ -116,7 +113,8 @@ class ActivityManager extends ChangeNotifier {
   Map<StatType, double> get dailyGains {
     final gains = <StatType, double>{};
 
-    for (final entry in _dailyCompletions.entries) {
+    final dailyCompletions = character.activityCompletions;
+    for (final entry in dailyCompletions.entries) {
       final activityId = entry.key;
       final completions = entry.value;
       final record = character.getCompletionRecord(activityId);
@@ -218,11 +216,6 @@ class ActivityManager extends ChangeNotifier {
   }) {
     if (_currentProgress == null) return;
 
-    if (grantPartialRewards && _currentProgress!.progress > 0) {
-      // Partial completions don't count towards daily stats in the new system
-      // (only full completions above record give stats)
-    }
-
     // Save partial progress before stopping (unless granting rewards)
     if (saveProgress && !grantPartialRewards) {
       _saveCurrentProgress();
@@ -296,10 +289,7 @@ class ActivityManager extends ChangeNotifier {
   void _onActivityComplete() {
     final activity = _currentProgress!.activity;
 
-    // Record the completion for daily stats
-    _recordCompletion(activity, 1.0);
-
-    // Increment this activity's completion count (increases its difficulty)
+    // Track completion for daily stats and difficulty.
     character.addCompletion(activity.id);
 
     // Clear any saved progress since activity completed
@@ -427,9 +417,8 @@ class ActivityManager extends ChangeNotifier {
 
   /// Estimates the total in-game time for the current plan.
   ///
-  /// Since stats are now applied at day end (not during the day), this
-  /// calculation only needs to account for difficulty increasing with each
-  /// completion (1.10x per completion), making it simpler and more accurate.
+  /// The estimate accounts for difficulty increasing with each completion
+  /// (1.10x per completion).
   double estimatePlanTime() {
     if (!_planner.hasPlannedActivities) return 0.0;
 
@@ -489,25 +478,14 @@ class ActivityManager extends ChangeNotifier {
     return result;
   }
 
-  /// Records a completion for tracking daily stats.
-  ///
-  /// Note: [multiplier] is ignored since stats are based on completion count,
-  /// not partial completions.
-  void _recordCompletion(Activity activity, double multiplier) {
-    // Only count full completions (multiplier == 1.0)
-    if (multiplier >= 1.0) {
-      _dailyCompletions[activity.id] =
-          (_dailyCompletions[activity.id] ?? 0) + 1;
-    }
-  }
-
   /// Starts a new day, applying stat gains and resetting time.
   ///
   /// Only completions above the character's record give stat gains.
   /// This should be called when the user dismisses the day end modal.
   void startNewDay() {
     // Calculate and apply stat gains based on new levels above records
-    for (final entry in _dailyCompletions.entries) {
+    final dailyCompletions = character.activityCompletions;
+    for (final entry in dailyCompletions.entries) {
       final activityId = entry.key;
       final completions = entry.value;
 
@@ -531,10 +509,7 @@ class ActivityManager extends ChangeNotifier {
       }
     }
 
-    // Reset daily completions
-    _dailyCompletions.clear();
-
-    // Reset activity difficulty (completions used for difficulty coefficient)
+    // Reset daily completions and activity difficulty.
     character.resetCompletions();
 
     // Start a new day in the game time
@@ -548,7 +523,7 @@ class ActivityManager extends ChangeNotifier {
 
   /// Clears daily completions without applying them.
   void clearDailyCompletions() {
-    _dailyCompletions.clear();
+    character.resetCompletions();
     notifyListeners();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -99,6 +99,9 @@ class _GameScreenState extends State<GameScreen>
     // Listen to activity manager changes
     _activityManager.addListener(_onActivityManagerChanged);
 
+    // Set up day expired callback
+    _activityManager.onDayExpired = _onDayExpired;
+
     // Load saved game and start
     _initializeGame();
   }
@@ -142,6 +145,27 @@ class _GameScreenState extends State<GameScreen>
 
   void _onActivityManagerChanged() {
     setState(() {});
+  }
+
+  void _onDayExpired(Map<StatType, double> dailyGains) {
+    // Show the day end modal
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _showDayEndModal(dailyGains);
+    });
+  }
+
+  void _showDayEndModal(Map<StatType, double> dailyGains) {
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => DayEndModal(
+        dayCount: _gameTime.dayCount,
+        dailyGains: dailyGains,
+        onStartNewDay: () {
+          _activityManager.startNewDay();
+        },
+      ),
+    );
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -168,6 +168,30 @@ class _GameScreenState extends State<GameScreen>
     );
   }
 
+  void _handleReset() {
+    // Stop any running activity
+    _activityManager.stopActivity();
+
+    // Reset character to default state
+    _character.restoreFrom(Character(name: 'Player'));
+
+    // Reset game time
+    _gameTime.reset();
+
+    // Clear daily completions
+    _activityManager.clearDailyCompletions();
+
+    // Delete saved data
+    _saveManager.deleteSave();
+
+    // Resume game loop if paused
+    if (_gameLoop.isPaused) {
+      _gameLoop.resume();
+    }
+
+    setState(() {});
+  }
+
   @override
   void dispose() {
     _activityManager.removeListener(_onActivityManagerChanged);
@@ -199,6 +223,7 @@ class _GameScreenState extends State<GameScreen>
             themeProvider: widget.themeProvider,
             saveManager: _saveManager,
             onImport: _handleImport,
+            onReset: _handleReset,
             isPaused: _gameLoop.isPaused,
             onTogglePause: _togglePause,
           ),
@@ -237,6 +262,7 @@ class _GameScreenState extends State<GameScreen>
                       character: _character,
                       currentActivityId: _activityManager.currentActivity?.id,
                       hasActiveActivity: _activityManager.hasActiveActivity,
+                      dailyCompletions: _activityManager.dailyCompletions,
                       onStartActivity: _handleStartActivity,
                     ),
                   ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -262,7 +262,6 @@ class _GameScreenState extends State<GameScreen>
                       character: _character,
                       currentActivityId: _activityManager.currentActivity?.id,
                       hasActiveActivity: _activityManager.hasActiveActivity,
-                      dailyCompletions: _activityManager.dailyCompletions,
                       onStartActivity: _handleStartActivity,
                     ),
                   ],

--- a/lib/models/character.dart
+++ b/lib/models/character.dart
@@ -124,9 +124,11 @@ class Character {
     CharacterStats? stats,
     Map<String, int>? activityCompletions,
     Map<String, double>? savedActivityProgress,
+    Map<String, int>? completionRecords,
   }) : stats = stats ?? CharacterStats(),
        _activityCompletions = activityCompletions ?? {},
-       _savedActivityProgress = savedActivityProgress ?? {};
+       _savedActivityProgress = savedActivityProgress ?? {},
+       _completionRecords = completionRecords ?? {};
 
   /// Creates a [Character] instance from a JSON map.
   factory Character.fromJson(Map<String, dynamic> json) {
@@ -144,6 +146,13 @@ class Character {
         (key, value) => MapEntry(key.toString(), (value as num).toDouble()),
       );
     }
+    final recordsRaw = json['completionRecords'];
+    Map<String, int>? records;
+    if (recordsRaw != null && recordsRaw is Map) {
+      records = recordsRaw.map(
+        (key, value) => MapEntry(key.toString(), (value as num).toInt()),
+      );
+    }
     return Character(
       name: json['name'] as String? ?? 'Player',
       stats: json['stats'] != null
@@ -151,6 +160,7 @@ class Character {
           : null,
       activityCompletions: completions,
       savedActivityProgress: savedProgress,
+      completionRecords: records,
     );
   }
 
@@ -161,6 +171,7 @@ class Character {
       'stats': stats.toJson(),
       'activityCompletions': _activityCompletions,
       'savedActivityProgress': _savedActivityProgress,
+      'completionRecords': _completionRecords,
     };
   }
 
@@ -177,6 +188,10 @@ class Character {
   /// Saved partial progress for activities (by activity ID).
   /// Stores the progress percentage (0.0 to 1.0) when switching activities.
   final Map<String, double> _savedActivityProgress;
+
+  /// Record of max completions reached in a single day per activity.
+  /// Used to determine stat gains - only completions above the record give stats.
+  final Map<String, int> _completionRecords;
 
   /// Gets the number of completions for a specific activity.
   int getCompletions(String activityId) {
@@ -228,6 +243,27 @@ class Character {
   Map<String, int> get activityCompletions =>
       Map<String, int>.from(_activityCompletions);
 
+  /// Gets the completion record for a specific activity.
+  /// This is the max completions reached in any single day.
+  int getCompletionRecord(String activityId) {
+    return _completionRecords[activityId] ?? 0;
+  }
+
+  /// Updates the completion record for an activity if the new value is higher.
+  /// Returns the number of new levels gained (completions - oldRecord).
+  int updateCompletionRecord(String activityId, int completions) {
+    final oldRecord = _completionRecords[activityId] ?? 0;
+    if (completions > oldRecord) {
+      _completionRecords[activityId] = completions;
+      return completions - oldRecord;
+    }
+    return 0;
+  }
+
+  /// Gets a copy of the completion records map.
+  Map<String, int> get completionRecords =>
+      Map<String, int>.from(_completionRecords);
+
   /// Restores state from another character (used when loading a save).
   void restoreFrom(Character other) {
     stats.strength = other.stats.strength;
@@ -241,6 +277,9 @@ class Character {
     _savedActivityProgress
       ..clear()
       ..addAll(other._savedActivityProgress);
+    _completionRecords
+      ..clear()
+      ..addAll(other._completionRecords);
   }
 
   /// Simple power function for double base and int exponent.

--- a/lib/models/character.dart
+++ b/lib/models/character.dart
@@ -204,6 +204,11 @@ class Character {
         (_activityCompletions[activityId] ?? 0) + 1;
   }
 
+  /// Resets all activity completions (difficulty resets at day start).
+  void resetCompletions() {
+    _activityCompletions.clear();
+  }
+
   /// Saves partial progress for an activity.
   void saveActivityProgress(String activityId, double progress) {
     if (progress > 0 && progress < 1.0) {

--- a/lib/models/game_time.dart
+++ b/lib/models/game_time.dart
@@ -2,6 +2,8 @@
 ///
 /// The in-game clock runs at [timeMultiplier] speed relative to real time.
 /// By default, 1 real second = 300 in-game seconds (5 in-game minutes).
+/// Time stops at 24:00 (86400 seconds) and must be manually reset via
+/// [startNewDay] to continue.
 class GameTime {
   /// Creates a new [GameTime] instance.
   GameTime({
@@ -55,14 +57,20 @@ class GameTime {
   /// Total real time played in milliseconds (not displayed).
   double _realTimePlayedMs;
 
-  /// Current in-game hour (0-23).
-  int get hour => (_inGameSeconds ~/ 3600) % 24;
+  /// The maximum in-game seconds in a day (24:00 = 86400 seconds).
+  static const double maxDaySeconds = 86400.0;
 
-  /// Current in-game minute (0-59).
-  int get minute => (_inGameSeconds ~/ 60).toInt() % 60;
+  /// Current in-game hour (0-24). Returns 24 when day is expired.
+  int get hour => isExpired ? 24 : (_inGameSeconds ~/ 3600) % 24;
 
-  /// Current in-game second (0-59).
-  int get second => _inGameSeconds.toInt() % 60;
+  /// Current in-game minute (0-59). Returns 0 when day is expired.
+  int get minute => isExpired ? 0 : (_inGameSeconds ~/ 60).toInt() % 60;
+
+  /// Current in-game second (0-59). Returns 0 when day is expired.
+  int get second => isExpired ? 0 : _inGameSeconds.toInt() % 60;
+
+  /// Whether the day has expired (reached 24:00).
+  bool get isExpired => _inGameSeconds >= maxDaySeconds;
 
   /// Current day count since game start.
   int get dayCount => _dayCount;
@@ -97,7 +105,12 @@ class GameTime {
   /// Updates the game time based on real time elapsed.
   ///
   /// [realDeltaTimeMs] is the real time elapsed in milliseconds.
+  /// Time will stop at 24:00 (86400 seconds) and will not roll over.
+  /// Use [startNewDay] to advance to the next day.
   void update(double realDeltaTimeMs) {
+    // Don't update if day is already expired
+    if (isExpired) return;
+
     // Track real time played
     _realTimePlayedMs += realDeltaTimeMs;
 
@@ -105,11 +118,19 @@ class GameTime {
     final inGameDeltaSeconds = (realDeltaTimeMs / 1000.0) * timeMultiplier;
     _inGameSeconds += inGameDeltaSeconds;
 
-    // Handle day rollover
-    while (_inGameSeconds >= 86400) {
-      _inGameSeconds -= 86400;
-      _dayCount++;
+    // Cap at 24:00 instead of rolling over
+    if (_inGameSeconds >= maxDaySeconds) {
+      _inGameSeconds = maxDaySeconds;
     }
+  }
+
+  /// Starts a new day, resetting the time to the initial hour.
+  ///
+  /// This increments the day count and resets the in-game time.
+  /// Should be called after the day end modal is dismissed.
+  void startNewDay({int initialHour = 8, int initialMinute = 0}) {
+    _inGameSeconds = (initialHour * 3600 + initialMinute * 60).toDouble();
+    _dayCount++;
   }
 
   /// Resets the game time to the initial state.

--- a/lib/widgets/activities_card.dart
+++ b/lib/widgets/activities_card.dart
@@ -13,6 +13,7 @@ class ActivitiesCard extends StatelessWidget {
     required this.currentActivityId,
     required this.hasActiveActivity,
     required this.onStartActivity,
+    this.dailyCompletions = const {},
   });
 
   final List<Activity> activities;
@@ -20,6 +21,9 @@ class ActivitiesCard extends StatelessWidget {
   final String? currentActivityId;
   final bool hasActiveActivity;
   final void Function(Activity activity) onStartActivity;
+
+  /// Daily completions per activity ID.
+  final Map<String, int> dailyCompletions;
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +48,8 @@ class ActivitiesCard extends StatelessWidget {
                   isCurrentActivity: currentActivityId == activity.id,
                   canStart: !hasActiveActivity,
                   onStart: () => onStartActivity(activity),
+                  dailyCompletions: dailyCompletions[activity.id] ?? 0,
+                  maxCompletions: character.getCompletionRecord(activity.id),
                 );
               },
             ),

--- a/lib/widgets/activities_card.dart
+++ b/lib/widgets/activities_card.dart
@@ -13,7 +13,6 @@ class ActivitiesCard extends StatelessWidget {
     required this.currentActivityId,
     required this.hasActiveActivity,
     required this.onStartActivity,
-    this.dailyCompletions = const {},
   });
 
   final List<Activity> activities;
@@ -21,9 +20,6 @@ class ActivitiesCard extends StatelessWidget {
   final String? currentActivityId;
   final bool hasActiveActivity;
   final void Function(Activity activity) onStartActivity;
-
-  /// Daily completions per activity ID.
-  final Map<String, int> dailyCompletions;
 
   @override
   Widget build(BuildContext context) {
@@ -48,8 +44,6 @@ class ActivitiesCard extends StatelessWidget {
                   isCurrentActivity: currentActivityId == activity.id,
                   canStart: !hasActiveActivity,
                   onStart: () => onStartActivity(activity),
-                  dailyCompletions: dailyCompletions[activity.id] ?? 0,
-                  maxCompletions: character.getCompletionRecord(activity.id),
                 );
               },
             ),

--- a/lib/widgets/activity_list_item.dart
+++ b/lib/widgets/activity_list_item.dart
@@ -12,6 +12,8 @@ class ActivityListItem extends StatelessWidget {
     required this.isCurrentActivity,
     required this.canStart,
     required this.onStart,
+    this.dailyCompletions = 0,
+    this.maxCompletions = 0,
   });
 
   final Activity activity;
@@ -20,10 +22,15 @@ class ActivityListItem extends StatelessWidget {
   final bool canStart;
   final VoidCallback onStart;
 
+  /// Number of completions for this activity today.
+  final int dailyCompletions;
+
+  /// Record (max) completions for this activity.
+  final int maxCompletions;
+
   @override
   Widget build(BuildContext context) {
     final meetsRequirements = activity.meetsRequirements(character.stats);
-    final completions = character.getCompletions(activity.id);
     final coefficient = character.getDifficultyCoefficient(activity.id);
     final duration = activity.calculateDuration(
       character.stats,
@@ -35,14 +42,19 @@ class ActivityListItem extends StatelessWidget {
           ? Theme.of(context).colorScheme.primaryContainer
           : null,
       child: ListTile(
-        title: Text(activity.name),
+        title: Row(
+          children: [
+            Expanded(child: Text(activity.name)),
+            _CompletionBadge(daily: dailyCompletions, max: maxCompletions),
+          ],
+        ),
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(activity.description),
             const SizedBox(height: 4),
             Text(
-              'Duration: ${duration.toStringAsFixed(1)}s | x$completions',
+              'Duration: ${duration.toStringAsFixed(1)}s',
               style: Theme.of(context).textTheme.bodySmall,
             ),
             Text(
@@ -67,5 +79,48 @@ class ActivityListItem extends StatelessWidget {
           return '+${e.value.toStringAsFixed(2)} $statName';
         })
         .join(', ');
+  }
+}
+
+/// Badge showing daily and max completions for an activity.
+class _CompletionBadge extends StatelessWidget {
+  const _CompletionBadge({required this.daily, required this.max});
+
+  final int daily;
+  final int max;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isNewRecord = daily > max;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: isNewRecord
+            ? Colors.green.withValues(alpha: 0.2)
+            : theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+        border: isNewRecord ? Border.all(color: Colors.green, width: 1) : null,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '$daily',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: isNewRecord ? Colors.green[700] : null,
+            ),
+          ),
+          Text(
+            ' / $max',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/widgets/activity_list_item.dart
+++ b/lib/widgets/activity_list_item.dart
@@ -12,8 +12,6 @@ class ActivityListItem extends StatelessWidget {
     required this.isCurrentActivity,
     required this.canStart,
     required this.onStart,
-    this.dailyCompletions = 0,
-    this.maxCompletions = 0,
   });
 
   final Activity activity;
@@ -22,16 +20,12 @@ class ActivityListItem extends StatelessWidget {
   final bool canStart;
   final VoidCallback onStart;
 
-  /// Number of completions for this activity today.
-  final int dailyCompletions;
-
-  /// Record (max) completions for this activity.
-  final int maxCompletions;
-
   @override
   Widget build(BuildContext context) {
     final meetsRequirements = activity.meetsRequirements(character.stats);
     final coefficient = character.getDifficultyCoefficient(activity.id);
+    final dailyCompletions = character.getCompletions(activity.id);
+    final maxCompletions = character.getCompletionRecord(activity.id);
     final duration = activity.calculateDuration(
       character.stats,
       difficultyCoefficient: coefficient,

--- a/lib/widgets/activity_planner_card.dart
+++ b/lib/widgets/activity_planner_card.dart
@@ -4,6 +4,7 @@ import '../engine/activity_manager.dart';
 import '../engine/activity_planner.dart';
 import '../models/activity.dart';
 import '../models/character.dart';
+import '../models/game_time.dart';
 import '../models/planned_activity.dart';
 
 /// Displays the activity planner with queued activities.
@@ -22,6 +23,7 @@ class ActivityPlannerCard extends StatelessWidget {
   final VoidCallback onCancelPlan;
 
   ActivityPlanner get planner => activityManager.planner;
+  GameTime get gameTime => activityManager.gameTime;
 
   @override
   Widget build(BuildContext context) {
@@ -61,18 +63,54 @@ class ActivityPlannerCard extends StatelessWidget {
         ? _formatDuration(estimatedTime)
         : 'Unlimited';
 
-    return Row(
+    // Calculate remaining time in the day
+    final remainingTime = GameTime.maxDaySeconds - gameTime.inGameSeconds;
+    final exceedsDay = estimatedTime.isFinite && estimatedTime > remainingTime;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Icon(
-          Icons.schedule,
-          size: 16,
-          color: Theme.of(context).colorScheme.primary,
+        Row(
+          children: [
+            Icon(
+              Icons.schedule,
+              size: 16,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              'Estimated time: $timeText',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
         ),
-        const SizedBox(width: 4),
-        Text(
-          'Estimated time: $timeText',
-          style: Theme.of(context).textTheme.bodySmall,
-        ),
+        if (exceedsDay) ...[
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.orange.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(color: Colors.orange, width: 1),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.warning_amber, size: 16, color: Colors.orange[800]),
+                const SizedBox(width: 6),
+                Flexible(
+                  child: Text(
+                    'Plan exceeds remaining day time '
+                    '(${_formatDuration(remainingTime)} left)',
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodySmall?.copyWith(color: Colors.orange[900]),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/lib/widgets/day_end_modal.dart
+++ b/lib/widgets/day_end_modal.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+
+import '../models/character.dart';
+
+/// A modal dialog that displays when the day ends (time reaches 24:00).
+///
+/// Shows the accumulated stat gains for the day and provides a button
+/// to start a new day, which applies the stat gains to the character.
+class DayEndModal extends StatelessWidget {
+  const DayEndModal({
+    super.key,
+    required this.dayCount,
+    required this.dailyGains,
+    required this.onStartNewDay,
+  });
+
+  /// The current day number that just ended.
+  final int dayCount;
+
+  /// The accumulated stat gains for the day.
+  final Map<StatType, double> dailyGains;
+
+  /// Callback when the user wants to start a new day.
+  final VoidCallback onStartNewDay;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        children: [
+          const Icon(Icons.nights_stay, size: 28),
+          const SizedBox(width: 8),
+          Text('Day $dayCount Complete'),
+        ],
+      ),
+      content: SizedBox(
+        width: 300,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Time is up! Here are your gains for today:',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 16),
+            if (dailyGains.isEmpty)
+              Text(
+                'No stat gains today.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontStyle: FontStyle.italic,
+                  color: Colors.grey,
+                ),
+              )
+            else
+              ...dailyGains.entries.map(
+                (entry) =>
+                    _StatGainRow(statType: entry.key, value: entry.value),
+              ),
+            const SizedBox(height: 16),
+            Text(
+              'Press the button below to apply your gains and start a new day.',
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: Colors.grey[600]),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        FilledButton.icon(
+          onPressed: () {
+            onStartNewDay();
+            Navigator.of(context).pop();
+          },
+          icon: const Icon(Icons.wb_sunny),
+          label: const Text('Start New Day'),
+        ),
+      ],
+    );
+  }
+}
+
+/// A row displaying a stat gain with its icon and value.
+class _StatGainRow extends StatelessWidget {
+  const _StatGainRow({required this.statType, required this.value});
+
+  final StatType statType;
+  final double value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Icon(
+            _getStatIcon(statType),
+            size: 20,
+            color: _getStatColor(statType),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              _getStatName(statType),
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          Text(
+            '+${value.toStringAsFixed(2)}',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: Colors.green[700],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getStatName(StatType type) {
+    switch (type) {
+      case StatType.strength:
+        return 'Strength';
+      case StatType.intelligence:
+        return 'Intelligence';
+      case StatType.endurance:
+        return 'Endurance';
+      case StatType.charisma:
+        return 'Charisma';
+      case StatType.agility:
+        return 'Agility';
+    }
+  }
+
+  IconData _getStatIcon(StatType type) {
+    switch (type) {
+      case StatType.strength:
+        return Icons.fitness_center;
+      case StatType.intelligence:
+        return Icons.psychology;
+      case StatType.endurance:
+        return Icons.favorite;
+      case StatType.charisma:
+        return Icons.record_voice_over;
+      case StatType.agility:
+        return Icons.directions_run;
+    }
+  }
+
+  Color _getStatColor(StatType type) {
+    switch (type) {
+      case StatType.strength:
+        return Colors.red;
+      case StatType.intelligence:
+        return Colors.blue;
+      case StatType.endurance:
+        return Colors.green;
+      case StatType.charisma:
+        return Colors.orange;
+      case StatType.agility:
+        return Colors.purple;
+    }
+  }
+}

--- a/lib/widgets/responsive_app_bar_actions.dart
+++ b/lib/widgets/responsive_app_bar_actions.dart
@@ -168,28 +168,31 @@ class ResponsiveAppBarActions extends StatelessWidget {
     );
   }
 
-  void _handleMenuSelection(BuildContext context, String value) {
+  Future<void> _handleMenuSelection(BuildContext context, String value) async {
+    final saveActions = SaveMenuActions(
+      saveManager: saveManager,
+      onImport: onImport,
+      onReset: onReset,
+    );
+
     switch (value) {
       case 'toggle_dark_mode':
-        themeProvider.toggleDarkMode();
+        await themeProvider.toggleDarkMode();
+        return;
       case 'theme':
-        _showThemeDialog(context);
+        await _showThemeDialog(context);
+        return;
       case 'save':
-        saveManager.save();
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('Game saved')));
       case 'export':
-        _exportSave(context);
       case 'import':
-        _showImportDialog(context);
       case 'reset':
-        _showResetDialog(context);
+        await saveActions.handleSelection(context, value);
+        return;
     }
   }
 
-  void _showThemeDialog(BuildContext context) {
-    showDialog<void>(
+  Future<void> _showThemeDialog(BuildContext context) {
+    return showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Select Theme'),
@@ -260,114 +263,5 @@ class ResponsiveAppBarActions extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  void _exportSave(BuildContext context) {
-    final jsonString = saveManager.exportSave();
-    if (jsonString != null) {
-      showDialog<void>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Export Save'),
-          content: SelectableText(
-            jsonString,
-            style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Close'),
-            ),
-          ],
-        ),
-      );
-    }
-  }
-
-  void _showImportDialog(BuildContext context) {
-    final controller = TextEditingController();
-    showDialog<void>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Import Save'),
-        content: TextField(
-          controller: controller,
-          maxLines: 5,
-          decoration: const InputDecoration(
-            hintText: 'Paste save data here...',
-            border: OutlineInputBorder(),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () {
-              final saveData = saveManager.importSave(controller.text);
-              if (saveData != null) {
-                onImport(saveData);
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Save imported successfully')),
-                );
-              } else {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Invalid save data')),
-                );
-              }
-            },
-            child: const Text('Import'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showResetDialog(BuildContext context) {
-    showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Row(
-          children: [
-            Icon(Icons.warning, color: Colors.red[700]),
-            const SizedBox(width: 8),
-            const Text('Reset Save'),
-          ],
-        ),
-        content: const Text(
-          'This will permanently delete all your progress and start a new game.\n\n'
-          'This action cannot be undone!\n\n'
-          'Are you sure you want to reset?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Colors.red[700],
-              foregroundColor: Colors.white,
-            ),
-            child: const Text('Reset'),
-          ),
-        ],
-      ),
-    ).then((confirm) {
-      if (confirm ?? false) {
-        onReset();
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Save reset successfully!'),
-              backgroundColor: Colors.orange,
-            ),
-          );
-        }
-      }
-    });
   }
 }

--- a/lib/widgets/responsive_app_bar_actions.dart
+++ b/lib/widgets/responsive_app_bar_actions.dart
@@ -18,6 +18,7 @@ class ResponsiveAppBarActions extends StatelessWidget {
     required this.themeProvider,
     required this.saveManager,
     required this.onImport,
+    required this.onReset,
     required this.isPaused,
     required this.onTogglePause,
   });
@@ -33,6 +34,9 @@ class ResponsiveAppBarActions extends StatelessWidget {
 
   /// Callback when a save is imported.
   final ValueChanged<GameSaveData> onImport;
+
+  /// Callback when the save is reset.
+  final VoidCallback onReset;
 
   /// Whether the game is paused.
   final bool isPaused;
@@ -58,7 +62,11 @@ class ResponsiveAppBarActions extends StatelessWidget {
             onThemeChanged: themeProvider.setTheme,
             onToggleDarkMode: themeProvider.toggleDarkMode,
           ),
-          SaveMenuButton(saveManager: saveManager, onImport: onImport),
+          SaveMenuButton(
+            saveManager: saveManager,
+            onImport: onImport,
+            onReset: onReset,
+          ),
           IconButton(
             icon: Icon(isPaused ? Icons.play_arrow : Icons.pause),
             onPressed: onTogglePause,
@@ -143,6 +151,17 @@ class ResponsiveAppBarActions extends StatelessWidget {
                 ],
               ),
             ),
+            const PopupMenuDivider(),
+            PopupMenuItem<String>(
+              value: 'reset',
+              child: Row(
+                children: [
+                  Icon(Icons.delete_forever, color: Colors.red[700]),
+                  const SizedBox(width: 12),
+                  Text('Reset save', style: TextStyle(color: Colors.red[700])),
+                ],
+              ),
+            ),
           ],
         ),
       ],
@@ -164,6 +183,8 @@ class ResponsiveAppBarActions extends StatelessWidget {
         _exportSave(context);
       case 'import':
         _showImportDialog(context);
+      case 'reset':
+        _showResetDialog(context);
     }
   }
 
@@ -302,5 +323,51 @@ class ResponsiveAppBarActions extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  void _showResetDialog(BuildContext context) {
+    showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Row(
+          children: [
+            Icon(Icons.warning, color: Colors.red[700]),
+            const SizedBox(width: 8),
+            const Text('Reset Save'),
+          ],
+        ),
+        content: const Text(
+          'This will permanently delete all your progress and start a new game.\n\n'
+          'This action cannot be undone!\n\n'
+          'Are you sure you want to reset?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Colors.red[700],
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Reset'),
+          ),
+        ],
+      ),
+    ).then((confirm) {
+      if (confirm ?? false) {
+        onReset();
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Save reset successfully!'),
+              backgroundColor: Colors.orange,
+            ),
+          );
+        }
+      }
+    });
   }
 }

--- a/lib/widgets/save_menu_button.dart
+++ b/lib/widgets/save_menu_button.dart
@@ -3,12 +3,13 @@ import 'package:flutter/services.dart';
 
 import '../engine/save_manager.dart';
 
-/// A menu button that provides save, export, and import functionality.
+/// A menu button that provides save, export, import, and reset functionality.
 class SaveMenuButton extends StatelessWidget {
   /// Creates a new [SaveMenuButton].
   const SaveMenuButton({
     required this.saveManager,
     required this.onImport,
+    required this.onReset,
     super.key,
   });
 
@@ -17,6 +18,9 @@ class SaveMenuButton extends StatelessWidget {
 
   /// Callback when a save is imported successfully.
   final void Function(GameSaveData) onImport;
+
+  /// Callback when the save is reset.
+  final VoidCallback onReset;
 
   @override
   Widget build(BuildContext context) {
@@ -49,6 +53,15 @@ class SaveMenuButton extends StatelessWidget {
             contentPadding: EdgeInsets.zero,
           ),
         ),
+        const PopupMenuDivider(),
+        PopupMenuItem<String>(
+          value: 'reset',
+          child: ListTile(
+            leading: Icon(Icons.delete_forever, color: Colors.red[700]),
+            title: Text('Reset Save', style: TextStyle(color: Colors.red[700])),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
       ],
     );
   }
@@ -61,6 +74,8 @@ class SaveMenuButton extends StatelessWidget {
         await _handleExport(context);
       case 'import':
         await _handleImport(context);
+      case 'reset':
+        await _handleReset(context);
     }
   }
 
@@ -253,6 +268,52 @@ class SaveMenuButton extends StatelessWidget {
           const SnackBar(
             content: Text('Save imported successfully!'),
             backgroundColor: Colors.green,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _handleReset(BuildContext context) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Row(
+          children: [
+            Icon(Icons.warning, color: Colors.red[700]),
+            const SizedBox(width: 8),
+            const Text('Reset Save'),
+          ],
+        ),
+        content: const Text(
+          'This will permanently delete all your progress and start a new game.\n\n'
+          'This action cannot be undone!\n\n'
+          'Are you sure you want to reset?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Colors.red[700],
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Reset'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm ?? false) {
+      onReset();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Save reset successfully!'),
+            backgroundColor: Colors.orange,
           ),
         );
       }

--- a/lib/widgets/save_menu_button.dart
+++ b/lib/widgets/save_menu_button.dart
@@ -3,70 +3,19 @@ import 'package:flutter/services.dart';
 
 import '../engine/save_manager.dart';
 
-/// A menu button that provides save, export, import, and reset functionality.
-class SaveMenuButton extends StatelessWidget {
-  /// Creates a new [SaveMenuButton].
-  const SaveMenuButton({
+/// Shared actions for save, export, import, and reset dialogs.
+class SaveMenuActions {
+  const SaveMenuActions({
     required this.saveManager,
     required this.onImport,
     required this.onReset,
-    super.key,
   });
 
-  /// The save manager instance.
   final SaveManager saveManager;
-
-  /// Callback when a save is imported successfully.
   final void Function(GameSaveData) onImport;
-
-  /// Callback when the save is reset.
   final VoidCallback onReset;
 
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<String>(
-      icon: const Icon(Icons.save),
-      tooltip: 'Save Menu',
-      onSelected: (value) => _handleMenuSelection(context, value),
-      itemBuilder: (context) => [
-        const PopupMenuItem<String>(
-          value: 'save',
-          child: ListTile(
-            leading: Icon(Icons.save),
-            title: Text('Save Game'),
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-        const PopupMenuItem<String>(
-          value: 'export',
-          child: ListTile(
-            leading: Icon(Icons.upload),
-            title: Text('Export Save'),
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-        const PopupMenuItem<String>(
-          value: 'import',
-          child: ListTile(
-            leading: Icon(Icons.download),
-            title: Text('Import Save'),
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-        const PopupMenuDivider(),
-        PopupMenuItem<String>(
-          value: 'reset',
-          child: ListTile(
-            leading: Icon(Icons.delete_forever, color: Colors.red[700]),
-            title: Text('Reset Save', style: TextStyle(color: Colors.red[700])),
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Future<void> _handleMenuSelection(BuildContext context, String value) async {
+  Future<void> handleSelection(BuildContext context, String value) async {
     switch (value) {
       case 'save':
         await _handleSave(context);
@@ -318,5 +267,75 @@ class SaveMenuButton extends StatelessWidget {
         );
       }
     }
+  }
+}
+
+/// A menu button that provides save, export, import, and reset functionality.
+class SaveMenuButton extends StatelessWidget {
+  /// Creates a new [SaveMenuButton].
+  const SaveMenuButton({
+    required this.saveManager,
+    required this.onImport,
+    required this.onReset,
+    super.key,
+  });
+
+  /// The save manager instance.
+  final SaveManager saveManager;
+
+  /// Callback when a save is imported successfully.
+  final void Function(GameSaveData) onImport;
+
+  /// Callback when the save is reset.
+  final VoidCallback onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    final actions = SaveMenuActions(
+      saveManager: saveManager,
+      onImport: onImport,
+      onReset: onReset,
+    );
+
+    return PopupMenuButton<String>(
+      icon: const Icon(Icons.save),
+      tooltip: 'Save Menu',
+      onSelected: (value) => actions.handleSelection(context, value),
+      itemBuilder: (context) => [
+        const PopupMenuItem<String>(
+          value: 'save',
+          child: ListTile(
+            leading: Icon(Icons.save),
+            title: Text('Save Game'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'export',
+          child: ListTile(
+            leading: Icon(Icons.upload),
+            title: Text('Export Save'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'import',
+          child: ListTile(
+            leading: Icon(Icons.download),
+            title: Text('Import Save'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<String>(
+          value: 'reset',
+          child: ListTile(
+            leading: Icon(Icons.delete_forever, color: Colors.red[700]),
+            title: Text('Reset Save', style: TextStyle(color: Colors.red[700])),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -5,6 +5,7 @@ export 'activities_card.dart';
 export 'activity_list_item.dart';
 export 'activity_planner_card.dart';
 export 'activity_progress_card.dart';
+export 'day_end_modal.dart';
 export 'game_time_display.dart';
 export 'responsive_app_bar_actions.dart';
 export 'save_menu_button.dart';

--- a/test/activity_manager_test.dart
+++ b/test/activity_manager_test.dart
@@ -598,7 +598,7 @@ void main() {
       gameLoop.dispose();
     });
 
-    test('should accumulate daily gains instead of applying immediately', () {
+    test('should track daily completions instead of applying immediately', () {
       // Initial stats
       final initialEndurance = character.stats.endurance;
 
@@ -611,34 +611,112 @@ void main() {
       // Stats should NOT have changed yet
       expect(character.stats.endurance, equals(initialEndurance));
 
-      // But daily gains should have accumulated
+      // But daily completions should be tracked
+      expect(activityManager.dailyCompletions['working'], equals(1));
+
+      // And daily gains should show the expected gains
       expect(activityManager.dailyGains.isNotEmpty, isTrue);
       expect(activityManager.dailyGains[StatType.endurance], greaterThan(0));
     });
 
-    test('startNewDay should apply accumulated gains', () {
+    test('startNewDay should apply gains only for new levels above record', () {
       final initialEndurance = character.stats.endurance;
 
-      // Complete an activity to accumulate gains
+      // Enable auto-repeat to complete multiple times
+      activityManager.autoRepeat = true;
       activityManager.startActivity(Activities.working, force: true);
-      tickerProvider.ticker!.advance(const Duration(milliseconds: 5000));
 
-      // Get the accumulated gain
-      final accumulatedEndurance =
-          activityManager.dailyGains[StatType.endurance] ?? 0;
-      expect(accumulatedEndurance, greaterThan(0));
+      // Working: duration starts at ~5s, increases with each completion
+      // Advance in small increments to allow multiple completions
+      // Complete 3 times (need ~17s total with increasing difficulty)
+      for (var i = 0; i < 20; i++) {
+        tickerProvider.ticker!.advance(const Duration(milliseconds: 1000));
+      }
+
+      expect(activityManager.dailyCompletions['working'], equals(3));
+
+      // Get the expected gains (3 new levels, since record is 0)
+      final expectedGains = activityManager.dailyGains;
+      expect(expectedGains[StatType.endurance], greaterThan(0));
 
       // Start a new day
       activityManager.startNewDay();
 
       // Stats should now be applied
+      expect(character.stats.endurance, greaterThan(initialEndurance));
+
+      // Record should be updated
+      expect(character.getCompletionRecord('working'), equals(3));
+
+      // Daily completions should be cleared
+      expect(activityManager.dailyCompletions.isEmpty, isTrue);
+    });
+
+    test('should not gain stats if completions are below record', () {
+      // Set a pre-existing record of 5 completions
+      character.updateCompletionRecord('working', 5);
+      final initialEndurance = character.stats.endurance;
+
+      // Enable auto-repeat
+      activityManager.autoRepeat = true;
+      activityManager.startActivity(Activities.working, force: true);
+
+      // Complete activity only 3 times (below record of 5)
+      for (var i = 0; i < 20; i++) {
+        tickerProvider.ticker!.advance(const Duration(milliseconds: 1000));
+      }
+
+      expect(activityManager.dailyCompletions['working'], equals(3));
+
+      // Daily gains should be empty (3 < 5 record)
+      expect(activityManager.dailyGains.isEmpty, isTrue);
+
+      // Start a new day
+      activityManager.startNewDay();
+
+      // Stats should NOT have changed
+      expect(character.stats.endurance, equals(initialEndurance));
+
+      // Record should still be 5
+      expect(character.getCompletionRecord('working'), equals(5));
+    });
+
+    test('should only gain stats for levels above record', () {
+      // Set a pre-existing record of 2 completions
+      character.updateCompletionRecord('working', 2);
+      final initialEndurance = character.stats.endurance;
+
+      // Enable auto-repeat
+      activityManager.autoRepeat = true;
+      activityManager.startActivity(Activities.working, force: true);
+
+      // Complete activity 5 times (3 above record)
+      // Each completion takes longer due to difficulty increase
+      for (var i = 0; i < 40; i++) {
+        tickerProvider.ticker!.advance(const Duration(milliseconds: 1000));
+      }
+
+      expect(activityManager.dailyCompletions['working'], equals(5));
+
+      // Daily gains should be for 3 new levels (5 - 2 = 3)
+      final workingRewards = Activities.working.rewards;
+      final expectedEndurance = (workingRewards[StatType.endurance] ?? 0) * 3;
       expect(
-        character.stats.endurance,
-        closeTo(initialEndurance + accumulatedEndurance, 0.001),
+        activityManager.dailyGains[StatType.endurance],
+        closeTo(expectedEndurance, 0.001),
       );
 
-      // Daily gains should be cleared
-      expect(activityManager.dailyGains.isEmpty, isTrue);
+      // Start a new day
+      activityManager.startNewDay();
+
+      // Stats should have increased by 3x the reward
+      expect(
+        character.stats.endurance,
+        closeTo(initialEndurance + expectedEndurance, 0.001),
+      );
+
+      // Record should be updated to 5
+      expect(character.getCompletionRecord('working'), equals(5));
     });
 
     test('should stop activity and trigger callback when day expires', () {
@@ -695,9 +773,8 @@ void main() {
       // Advance time - should not process
       tickerProvider.ticker!.advance(const Duration(milliseconds: 5000));
 
-      // Activity might have been stopped immediately due to day expiry check
-      // The key is that no stats were gained
-      expect(activityManager.dailyGains.isEmpty, isTrue);
+      // No completions should be recorded
+      expect(activityManager.dailyCompletions.isEmpty, isTrue);
     });
   });
 }

--- a/test/activity_manager_test.dart
+++ b/test/activity_manager_test.dart
@@ -5,6 +5,7 @@ import 'package:just_another_day/engine/activity_manager.dart';
 import 'package:just_another_day/engine/game_loop.dart';
 import 'package:just_another_day/models/activity.dart';
 import 'package:just_another_day/models/character.dart';
+import 'package:just_another_day/models/game_time.dart';
 import 'package:just_another_day/models/planned_activity.dart';
 
 /// A fake ticker for testing that allows manual time control.
@@ -309,10 +310,10 @@ void main() {
       gameLoop.dispose();
     });
 
-    test('should account for difficulty and stats evolution in estimation', () {
+    test('should account for difficulty increase in estimation', () {
       // Add 3 completions of working
       // Working: baseDuration=10, difficulty=0.5, primary=endurance
-      // Working rewards: endurance +0.1, charisma +0.05
+      // Stats don't evolve during the day anymore, only difficulty increases
       final planned = PlannedActivity(
         activity: Activities.working,
         targetType: PlanTargetType.completions,
@@ -321,16 +322,13 @@ void main() {
 
       activityManager.planner.addPlannedActivity(planned);
 
-      // With endurance=1.0:
-      // Completion 1: coef=1.0, end=1.0, dur = 10 * (0.5*1.0/1.0) = 5.0s
-      //   After: endurance = 1.1, completions = 1
-      // Completion 2: coef=1.1, end=1.1, dur = 10 * (0.5*1.1/1.1) = 5.0s
-      //   After: endurance = 1.2, completions = 2
-      // Completion 3: coef=1.21, end=1.2, dur = 10 * (0.5*1.21/1.2) = 5.04s
-      // Total = 5.0 + 5.0 + 5.04 = 15.04s
-      // Note: difficulty increase and stat increase roughly cancel out early on
+      // With endurance=1.0, stats fixed during day:
+      // Completion 1: coef=1.0, dur = 10 * (0.5*1.0/1.0) = 5.0s
+      // Completion 2: coef=1.1, dur = 10 * (0.5*1.1/1.0) = 5.5s
+      // Completion 3: coef=1.21, dur = 10 * (0.5*1.21/1.0) = 6.05s
+      // Total = 5.0 + 5.5 + 6.05 = 16.55s
       final estimate = activityManager.estimatePlanTime();
-      expect(estimate, closeTo(15.04, 0.1));
+      expect(estimate, closeTo(16.55, 0.1));
     });
 
     test('should handle existing completions in estimation', () {
@@ -349,13 +347,12 @@ void main() {
 
       // With endurance=1.0, existing completions=2:
       // Completion 1: coef=1.21, dur = 10 * (0.5*1.21/1.0) = 6.05s
-      //   After: endurance = 1.1, completions = 3
-      // Completion 2: coef=1.331, end=1.1, dur = 10 * (0.5*1.331/1.1) = 6.05s
+      // Completion 2: coef=1.331, dur = 10 * (0.5*1.331/1.0) = 6.655s
       final estimate = activityManager.estimatePlanTime();
-      expect(estimate, closeTo(12.1, 0.2));
+      expect(estimate, closeTo(12.7, 0.2));
     });
 
-    test('should estimate time-based targets with evolving stats', () {
+    test('should estimate time-based targets simply', () {
       final planned = PlannedActivity(
         activity: Activities.working,
         targetType: PlanTargetType.inGameTime,
@@ -364,16 +361,13 @@ void main() {
 
       activityManager.planner.addPlannedActivity(planned);
 
-      // Should account for completions happening within the time window
-      // and update stats/difficulty accordingly
+      // For time-based targets, the estimate is simply the target time
+      // (simplified since stats don't evolve during the day)
       final estimate = activityManager.estimatePlanTime();
-
-      // First completion takes 5s, second takes ~5s (stats offset difficulty)
-      // Third completion starts but only partial time remains
-      expect(estimate, equals(15)); // Time-based should equal target time
+      expect(estimate, equals(15));
     });
 
-    test('should handle multiple planned activities with evolution', () {
+    test('should handle multiple planned activities', () {
       // First: 2 completions of working
       final planned1 = PlannedActivity(
         activity: Activities.working,
@@ -393,9 +387,7 @@ void main() {
 
       final estimate = activityManager.estimatePlanTime();
 
-      // Working improves endurance, studying uses intelligence
-      // Stats from working don't directly help studying
-      // But the estimation should still be reasonable
+      // Estimation only considers difficulty increases, not stat changes
       expect(estimate, greaterThan(0));
       expect(estimate.isFinite, isTrue);
     });
@@ -581,6 +573,131 @@ void main() {
       expect(activityManager.planner.currentPlanned?.activity.id, 'studying');
       // Still no active activity
       expect(activityManager.hasActiveActivity, isFalse);
+    });
+  });
+
+  group('ActivityManager daily gains and day expiration', () {
+    late FakeTickerProvider tickerProvider;
+    late GameLoop gameLoop;
+    late Character character;
+    late ActivityManager activityManager;
+
+    setUp(() {
+      tickerProvider = FakeTickerProvider();
+      gameLoop = GameLoop(vsync: tickerProvider);
+      character = Character(name: 'TestPlayer');
+      activityManager = ActivityManager(
+        character: character,
+        gameLoop: gameLoop,
+      );
+      gameLoop.start();
+    });
+
+    tearDown(() {
+      activityManager.dispose();
+      gameLoop.dispose();
+    });
+
+    test('should accumulate daily gains instead of applying immediately', () {
+      // Initial stats
+      final initialEndurance = character.stats.endurance;
+
+      // Start working activity and complete it
+      activityManager.startActivity(Activities.working, force: true);
+
+      // Working: duration = 5 seconds = 5000ms
+      tickerProvider.ticker!.advance(const Duration(milliseconds: 5000));
+
+      // Stats should NOT have changed yet
+      expect(character.stats.endurance, equals(initialEndurance));
+
+      // But daily gains should have accumulated
+      expect(activityManager.dailyGains.isNotEmpty, isTrue);
+      expect(activityManager.dailyGains[StatType.endurance], greaterThan(0));
+    });
+
+    test('startNewDay should apply accumulated gains', () {
+      final initialEndurance = character.stats.endurance;
+
+      // Complete an activity to accumulate gains
+      activityManager.startActivity(Activities.working, force: true);
+      tickerProvider.ticker!.advance(const Duration(milliseconds: 5000));
+
+      // Get the accumulated gain
+      final accumulatedEndurance =
+          activityManager.dailyGains[StatType.endurance] ?? 0;
+      expect(accumulatedEndurance, greaterThan(0));
+
+      // Start a new day
+      activityManager.startNewDay();
+
+      // Stats should now be applied
+      expect(
+        character.stats.endurance,
+        closeTo(initialEndurance + accumulatedEndurance, 0.001),
+      );
+
+      // Daily gains should be cleared
+      expect(activityManager.dailyGains.isEmpty, isTrue);
+    });
+
+    test('should stop activity and trigger callback when day expires', () {
+      // Start at 23:59 with very fast time multiplier
+      final gameTime = GameTime(
+        initialHour: 23,
+        initialMinute: 59,
+        timeMultiplier: 3000.0, // 10x faster
+      );
+      activityManager = ActivityManager(
+        character: character,
+        gameLoop: gameLoop,
+        gameTime: gameTime,
+      );
+
+      bool dayExpiredCalled = false;
+      Map<StatType, double>? receivedGains;
+
+      activityManager.onDayExpired = (gains) {
+        dayExpiredCalled = true;
+        receivedGains = gains;
+      };
+
+      // Start an activity
+      activityManager.startActivity(Activities.working, force: true);
+      expect(activityManager.hasActiveActivity, isTrue);
+
+      // Advance time to expire the day
+      // 1 minute = 60 seconds, at 3000x that's 60/3000 = 0.02 real seconds = 20ms
+      tickerProvider.ticker!.advance(const Duration(milliseconds: 100));
+
+      // Day should be expired
+      expect(gameTime.isExpired, isTrue);
+      expect(dayExpiredCalled, isTrue);
+      expect(receivedGains, isNotNull);
+      // Activity should be stopped
+      expect(activityManager.hasActiveActivity, isFalse);
+    });
+
+    test('should not process activities after day expires', () {
+      // Create game time already expired
+      final gameTime = GameTime(initialHour: 23, initialMinute: 59);
+      gameTime.update(1000); // Expire the day
+
+      activityManager = ActivityManager(
+        character: character,
+        gameLoop: gameLoop,
+        gameTime: gameTime,
+      );
+
+      // Try to start an activity
+      activityManager.startActivity(Activities.working, force: true);
+
+      // Advance time - should not process
+      tickerProvider.ticker!.advance(const Duration(milliseconds: 5000));
+
+      // Activity might have been stopped immediately due to day expiry check
+      // The key is that no stats were gained
+      expect(activityManager.dailyGains.isEmpty, isTrue);
     });
   });
 }

--- a/test/game_time_test.dart
+++ b/test/game_time_test.dart
@@ -48,29 +48,66 @@ void main() {
       expect(gameTime.realTimePlayedMinutes, equals(1.0));
     });
 
-    test('should handle day rollover', () {
+    test('should stop at 24:00 instead of rolling over', () {
       // Start at 23:55
       final gameTime = GameTime(initialHour: 23, initialMinute: 55);
       expect(gameTime.dayCount, equals(1));
+      expect(gameTime.isExpired, isFalse);
 
       // Advance 2 real seconds = 600 game seconds = 10 game minutes
-      // 23:55 + 10 minutes = 00:05 next day
+      // 23:55 + 10 minutes would be 00:05, but should stop at 24:00
       gameTime.update(2000);
 
-      expect(gameTime.dayCount, equals(2));
-      expect(gameTime.hour, equals(0));
-      expect(gameTime.minute, equals(5));
+      expect(gameTime.dayCount, equals(1)); // Day doesn't change automatically
+      expect(gameTime.isExpired, isTrue);
+      expect(gameTime.hour, equals(24));
+      expect(gameTime.minute, equals(0));
     });
 
-    test('should handle multiple day rollovers', () {
-      final gameTime = GameTime(initialHour: 0, initialMinute: 0);
+    test('should not update time after day expires', () {
+      // Start at 23:59
+      final gameTime = GameTime(initialHour: 23, initialMinute: 59);
 
-      // 1 game day = 86400 game seconds
-      // At 300x, 1 game day = 288 real seconds
-      // Advance 576 real seconds = 2 game days
-      gameTime.update(576000); // 576 seconds in ms
+      // Advance to 24:00
+      gameTime.update(1000); // 5 game minutes
 
-      expect(gameTime.dayCount, equals(3)); // Started at day 1, +2 days
+      expect(gameTime.isExpired, isTrue);
+      final realTimeBeforeExpiry = gameTime.realTimePlayedMs;
+
+      // Try to update more - should be ignored
+      gameTime.update(10000);
+
+      // Real time should not have been tracked after expiry
+      expect(gameTime.realTimePlayedMs, equals(realTimeBeforeExpiry));
+      expect(gameTime.isExpired, isTrue);
+    });
+
+    test('startNewDay should reset time and increment day count', () {
+      // Start at 23:55 and expire
+      final gameTime = GameTime(initialHour: 23, initialMinute: 55);
+      gameTime.update(2000); // Expire the day
+      expect(gameTime.isExpired, isTrue);
+      expect(gameTime.dayCount, equals(1));
+
+      // Start a new day
+      gameTime.startNewDay();
+
+      expect(gameTime.isExpired, isFalse);
+      expect(gameTime.dayCount, equals(2));
+      expect(gameTime.hour, equals(8)); // Default initial hour
+      expect(gameTime.minute, equals(0));
+    });
+
+    test('startNewDay with custom time should work', () {
+      final gameTime = GameTime(initialHour: 23, initialMinute: 55);
+      gameTime.update(2000); // Expire
+      expect(gameTime.isExpired, isTrue);
+
+      gameTime.startNewDay(initialHour: 6, initialMinute: 30);
+
+      expect(gameTime.isExpired, isFalse);
+      expect(gameTime.hour, equals(6));
+      expect(gameTime.minute, equals(30));
     });
 
     test('should reset correctly', () {


### PR DESCRIPTION
Implement a day-end system that pauses the game loop at 24:00, accumulates daily stat gains, and presents a modal to start a new day.

This change simplifies stat management by applying all daily gains at once and streamlines activity time estimation. Pausing the game loop directly upon day expiration is a more efficient and cleaner approach than checking an `isExpired` flag on every tick.

---
<a href="https://cursor.com/background-agent?bcId=bc-83c4e52b-40b5-459c-b243-6771e8af8b65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83c4e52b-40b5-459c-b243-6771e8af8b65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

