### PR TITLE
Pull request comment

### DIFF
--- a/lib/engine/activity_manager.dart
+++ b/lib/engine/activity_manager.dart
@@ -62,10 +62,6 @@ class ActivityManager extends ChangeNotifier {
   PlannedActivityCompletedCallback? _onPlannedActivityCompleted;
   DayExpiredCallback? _onDayExpired;
 
-  /// Completions per activity for the current day.
-  /// At day end, only completions above the character's record give stat gains.
-  final Map<String, int> _dailyCompletions = {};
-
   /// The activity planner for managing the activity queue.
   ActivityPlanner get planner => _planner;
 
@@ -108,7 +104,8 @@ class ActivityManager extends ChangeNotifier {
   }
 
   /// Gets the daily completions per activity.
-  Map<String, int> get dailyCompletions => Map.unmodifiable(_dailyCompletions);
+  Map<String, int> get dailyCompletions =>
+      Map.unmodifiable(character.activityCompletions);
 
   /// Gets the expected stat gains for the current day.
   ///
@@ -116,7 +113,8 @@ class ActivityManager extends ChangeNotifier {
   Map<StatType, double> get dailyGains {
     final gains = <StatType, double>{};
 
-    for (final entry in _dailyCompletions.entries) {
+    final dailyCompletions = character.activityCompletions;
+    for (final entry in dailyCompletions.entries) {
       final activityId = entry.key;
       final completions = entry.value;
       final record = character.getCompletionRecord(activityId);
@@ -218,11 +216,6 @@ class ActivityManager extends ChangeNotifier {
   }) {
     if (_currentProgress == null) return;
 
-    if (grantPartialRewards && _currentProgress!.progress > 0) {
-      // Partial completions don't count towards daily stats in the new system
-      // (only full completions above record give stats)
-    }
-
     // Save partial progress before stopping (unless granting rewards)
     if (saveProgress && !grantPartialRewards) {
       _saveCurrentProgress();
@@ -296,10 +289,7 @@ class ActivityManager extends ChangeNotifier {
   void _onActivityComplete() {
     final activity = _currentProgress!.activity;
 
-    // Record the completion for daily stats
-    _recordCompletion(activity, 1.0);
-
-    // Increment this activity's completion count (increases its difficulty)
+    // Track completion for daily stats and difficulty.
     character.addCompletion(activity.id);
 
     // Clear any saved progress since activity completed
@@ -427,9 +417,8 @@ class ActivityManager extends ChangeNotifier {
 
   /// Estimates the total in-game time for the current plan.
   ///
-  /// Since stats are now applied at day end (not during the day), this
-  /// calculation only needs to account for difficulty increasing with each
-  /// completion (1.10x per completion), making it simpler and more accurate.
+  /// The estimate accounts for difficulty increasing with each completion
+  /// (1.10x per completion).
   double estimatePlanTime() {
     if (!_planner.hasPlannedActivities) return 0.0;
 
@@ -489,25 +478,14 @@ class ActivityManager extends ChangeNotifier {
     return result;
   }
 
-  /// Records a completion for tracking daily stats.
-  ///
-  /// Note: [multiplier] is ignored since stats are based on completion count,
-  /// not partial completions.
-  void _recordCompletion(Activity activity, double multiplier) {
-    // Only count full completions (multiplier == 1.0)
-    if (multiplier >= 1.0) {
-      _dailyCompletions[activity.id] =
-          (_dailyCompletions[activity.id] ?? 0) + 1;
-    }
-  }
-
   /// Starts a new day, applying stat gains and resetting time.
   ///
   /// Only completions above the character's record give stat gains.
   /// This should be called when the user dismisses the day end modal.
   void startNewDay() {
     // Calculate and apply stat gains based on new levels above records
-    for (final entry in _dailyCompletions.entries) {
+    final dailyCompletions = character.activityCompletions;
+    for (final entry in dailyCompletions.entries) {
       final activityId = entry.key;
       final completions = entry.value;
 
@@ -531,10 +509,7 @@ class ActivityManager extends ChangeNotifier {
       }
     }
 
-    // Reset daily completions
-    _dailyCompletions.clear();
-
-    // Reset activity difficulty (completions used for difficulty coefficient)
+    // Reset daily completions and activity difficulty.
     character.resetCompletions();
 
     // Start a new day in the game time
@@ -548,7 +523,7 @@ class ActivityManager extends ChangeNotifier {
 
   /// Clears daily completions without applying them.
   void clearDailyCompletions() {
-    _dailyCompletions.clear();
+    character.resetCompletions();
     notifyListeners();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -262,7 +262,6 @@ class _GameScreenState extends State<GameScreen>
                       character: _character,
                       currentActivityId: _activityManager.currentActivity?.id,
                       hasActiveActivity: _activityManager.hasActiveActivity,
-                      dailyCompletions: _activityManager.dailyCompletions,
                       onStartActivity: _handleStartActivity,
                     ),
                   ],

--- a/lib/widgets/activities_card.dart
+++ b/lib/widgets/activities_card.dart
@@ -13,7 +13,6 @@ class ActivitiesCard extends StatelessWidget {
     required this.currentActivityId,
     required this.hasActiveActivity,
     required this.onStartActivity,
-    this.dailyCompletions = const {},
   });
 
   final List<Activity> activities;
@@ -21,9 +20,6 @@ class ActivitiesCard extends StatelessWidget {
   final String? currentActivityId;
   final bool hasActiveActivity;
   final void Function(Activity activity) onStartActivity;
-
-  /// Daily completions per activity ID.
-  final Map<String, int> dailyCompletions;
 
   @override
   Widget build(BuildContext context) {
@@ -48,8 +44,6 @@ class ActivitiesCard extends StatelessWidget {
                   isCurrentActivity: currentActivityId == activity.id,
                   canStart: !hasActiveActivity,
                   onStart: () => onStartActivity(activity),
-                  dailyCompletions: dailyCompletions[activity.id] ?? 0,
-                  maxCompletions: character.getCompletionRecord(activity.id),
                 );
               },
             ),

--- a/lib/widgets/activity_list_item.dart
+++ b/lib/widgets/activity_list_item.dart
@@ -12,8 +12,6 @@ class ActivityListItem extends StatelessWidget {
     required this.isCurrentActivity,
     required this.canStart,
     required this.onStart,
-    this.dailyCompletions = 0,
-    this.maxCompletions = 0,
   });
 
   final Activity activity;
@@ -22,16 +20,12 @@ class ActivityListItem extends StatelessWidget {
   final bool canStart;
   final VoidCallback onStart;
 
-  /// Number of completions for this activity today.
-  final int dailyCompletions;
-
-  /// Record (max) completions for this activity.
-  final int maxCompletions;
-
   @override
   Widget build(BuildContext context) {
     final meetsRequirements = activity.meetsRequirements(character.stats);
     final coefficient = character.getDifficultyCoefficient(activity.id);
+    final dailyCompletions = character.getCompletions(activity.id);
+    final maxCompletions = character.getCompletionRecord(activity.id);
     final duration = activity.calculateDuration(
       character.stats,
       difficultyCoefficient: coefficient,

--- a/lib/widgets/responsive_app_bar_actions.dart
+++ b/lib/widgets/responsive_app_bar_actions.dart
@@ -177,19 +177,22 @@ class ResponsiveAppBarActions extends StatelessWidget {
 
     switch (value) {
       case 'toggle_dark_mode':
-        themeProvider.toggleDarkMode();
+        await themeProvider.toggleDarkMode();
+        return;
       case 'theme':
-        _showThemeDialog(context);
+        await _showThemeDialog(context);
+        return;
       case 'save':
       case 'export':
       case 'import':
       case 'reset':
         await saveActions.handleSelection(context, value);
+        return;
     }
   }
 
-  void _showThemeDialog(BuildContext context) {
-    showDialog<void>(
+  Future<void> _showThemeDialog(BuildContext context) {
+    return showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Select Theme'),

--- a/lib/widgets/responsive_app_bar_actions.dart
+++ b/lib/widgets/responsive_app_bar_actions.dart
@@ -168,23 +168,23 @@ class ResponsiveAppBarActions extends StatelessWidget {
     );
   }
 
-  void _handleMenuSelection(BuildContext context, String value) {
+  Future<void> _handleMenuSelection(BuildContext context, String value) async {
+    final saveActions = SaveMenuActions(
+      saveManager: saveManager,
+      onImport: onImport,
+      onReset: onReset,
+    );
+
     switch (value) {
       case 'toggle_dark_mode':
         themeProvider.toggleDarkMode();
       case 'theme':
         _showThemeDialog(context);
       case 'save':
-        saveManager.save();
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('Game saved')));
       case 'export':
-        _exportSave(context);
       case 'import':
-        _showImportDialog(context);
       case 'reset':
-        _showResetDialog(context);
+        await saveActions.handleSelection(context, value);
     }
   }
 
@@ -262,112 +262,4 @@ class ResponsiveAppBarActions extends StatelessWidget {
     );
   }
 
-  void _exportSave(BuildContext context) {
-    final jsonString = saveManager.exportSave();
-    if (jsonString != null) {
-      showDialog<void>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Export Save'),
-          content: SelectableText(
-            jsonString,
-            style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Close'),
-            ),
-          ],
-        ),
-      );
-    }
-  }
-
-  void _showImportDialog(BuildContext context) {
-    final controller = TextEditingController();
-    showDialog<void>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Import Save'),
-        content: TextField(
-          controller: controller,
-          maxLines: 5,
-          decoration: const InputDecoration(
-            hintText: 'Paste save data here...',
-            border: OutlineInputBorder(),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () {
-              final saveData = saveManager.importSave(controller.text);
-              if (saveData != null) {
-                onImport(saveData);
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Save imported successfully')),
-                );
-              } else {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Invalid save data')),
-                );
-              }
-            },
-            child: const Text('Import'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showResetDialog(BuildContext context) {
-    showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Row(
-          children: [
-            Icon(Icons.warning, color: Colors.red[700]),
-            const SizedBox(width: 8),
-            const Text('Reset Save'),
-          ],
-        ),
-        content: const Text(
-          'This will permanently delete all your progress and start a new game.\n\n'
-          'This action cannot be undone!\n\n'
-          'Are you sure you want to reset?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Colors.red[700],
-              foregroundColor: Colors.white,
-            ),
-            child: const Text('Reset'),
-          ),
-        ],
-      ),
-    ).then((confirm) {
-      if (confirm ?? false) {
-        onReset();
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Save reset successfully!'),
-              backgroundColor: Colors.orange,
-            ),
-          );
-        }
-      }
-    });
-  }
 }

--- a/lib/widgets/responsive_app_bar_actions.dart
+++ b/lib/widgets/responsive_app_bar_actions.dart
@@ -106,7 +106,9 @@ class ResponsiveAppBarActions extends StatelessWidget {
                         : Icons.dark_mode,
                   ),
                   const SizedBox(width: 12),
-                  Text(themeProvider.isDarkTheme ? 'Light mode' : 'Dark mode'),
+                  Text(
+                    themeProvider.isDarkTheme ? 'Light mode' : 'Dark mode',
+                  ),
                 ],
               ),
             ),
@@ -158,7 +160,10 @@ class ResponsiveAppBarActions extends StatelessWidget {
                 children: [
                   Icon(Icons.delete_forever, color: Colors.red[700]),
                   const SizedBox(width: 12),
-                  Text('Reset save', style: TextStyle(color: Colors.red[700])),
+                  Text(
+                    'Reset save',
+                    style: TextStyle(color: Colors.red[700]),
+                  ),
                 ],
               ),
             ),

--- a/lib/widgets/responsive_app_bar_actions.dart
+++ b/lib/widgets/responsive_app_bar_actions.dart
@@ -106,9 +106,7 @@ class ResponsiveAppBarActions extends StatelessWidget {
                         : Icons.dark_mode,
                   ),
                   const SizedBox(width: 12),
-                  Text(
-                    themeProvider.isDarkTheme ? 'Light mode' : 'Dark mode',
-                  ),
+                  Text(themeProvider.isDarkTheme ? 'Light mode' : 'Dark mode'),
                 ],
               ),
             ),
@@ -160,10 +158,7 @@ class ResponsiveAppBarActions extends StatelessWidget {
                 children: [
                   Icon(Icons.delete_forever, color: Colors.red[700]),
                   const SizedBox(width: 12),
-                  Text(
-                    'Reset save',
-                    style: TextStyle(color: Colors.red[700]),
-                  ),
+                  Text('Reset save', style: TextStyle(color: Colors.red[700])),
                 ],
               ),
             ),
@@ -266,5 +261,4 @@ class ResponsiveAppBarActions extends StatelessWidget {
       ),
     );
   }
-
 }

--- a/lib/widgets/save_menu_button.dart
+++ b/lib/widgets/save_menu_button.dart
@@ -3,70 +3,19 @@ import 'package:flutter/services.dart';
 
 import '../engine/save_manager.dart';
 
-/// A menu button that provides save, export, import, and reset functionality.
-class SaveMenuButton extends StatelessWidget {
-  /// Creates a new [SaveMenuButton].
-  const SaveMenuButton({
+/// Shared actions for save, export, import, and reset dialogs.
+class SaveMenuActions {
+  const SaveMenuActions({
     required this.saveManager,
     required this.onImport,
     required this.onReset,
-    super.key,
   });
 
-  /// The save manager instance.
   final SaveManager saveManager;
-
-  /// Callback when a save is imported successfully.
   final void Function(GameSaveData) onImport;
-
-  /// Callback when the save is reset.
   final VoidCallback onReset;
 
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<String>(
-      icon: const Icon(Icons.save),
-      tooltip: 'Save Menu',
-      onSelected: (value) => _handleMenuSelection(context, value),
-      itemBuilder: (context) => [
-        const PopupMenuItem<String>(
-          value: 'save',
-          child: ListTile(
-            leading: Icon(Icons.save),
-            title: Text('Save Game'),
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-        const PopupMenuItem<String>(
-          value: 'export',
-          child: ListTile(
-            leading: Icon(Icons.upload),
-            title: Text('Export Save'),
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-        const PopupMenuItem<String>(
-          value: 'import',
-          child: ListTile(
-            leading: Icon(Icons.download),
-            title: Text('Import Save'),
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-        const PopupMenuDivider(),
-        PopupMenuItem<String>(
-          value: 'reset',
-          child: ListTile(
-            leading: Icon(Icons.delete_forever, color: Colors.red[700]),
-            title: Text('Reset Save', style: TextStyle(color: Colors.red[700])),
-            contentPadding: EdgeInsets.zero,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Future<void> _handleMenuSelection(BuildContext context, String value) async {
+  Future<void> handleSelection(BuildContext context, String value) async {
     switch (value) {
       case 'save':
         await _handleSave(context);
@@ -318,5 +267,75 @@ class SaveMenuButton extends StatelessWidget {
         );
       }
     }
+  }
+}
+
+/// A menu button that provides save, export, import, and reset functionality.
+class SaveMenuButton extends StatelessWidget {
+  /// Creates a new [SaveMenuButton].
+  const SaveMenuButton({
+    required this.saveManager,
+    required this.onImport,
+    required this.onReset,
+    super.key,
+  });
+
+  /// The save manager instance.
+  final SaveManager saveManager;
+
+  /// Callback when a save is imported successfully.
+  final void Function(GameSaveData) onImport;
+
+  /// Callback when the save is reset.
+  final VoidCallback onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    final actions = SaveMenuActions(
+      saveManager: saveManager,
+      onImport: onImport,
+      onReset: onReset,
+    );
+
+    return PopupMenuButton<String>(
+      icon: const Icon(Icons.save),
+      tooltip: 'Save Menu',
+      onSelected: (value) => actions.handleSelection(context, value),
+      itemBuilder: (context) => [
+        const PopupMenuItem<String>(
+          value: 'save',
+          child: ListTile(
+            leading: Icon(Icons.save),
+            title: Text('Save Game'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'export',
+          child: ListTile(
+            leading: Icon(Icons.upload),
+            title: Text('Export Save'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'import',
+          child: ListTile(
+            leading: Icon(Icons.download),
+            title: Text('Import Save'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<String>(
+          value: 'reset',
+          child: ListTile(
+            leading: Icon(Icons.delete_forever, color: Colors.red[700]),
+            title: Text('Reset Save', style: TextStyle(color: Colors.red[700])),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    );
   }
 }


### PR DESCRIPTION
Implements a daily cycle for stat gains with a day-end summary and centralizes save/reset menu actions.

Previously, stat rewards were applied immediately upon activity completion, leading to potential issues with daily tracking and inconsistent difficulty scaling. This change ensures stat gains are accumulated throughout the day and applied only once at day's end, based on completions exceeding the character's historical record for each activity. This provides a clearer daily progression loop and fixes potential inconsistencies in stat application and difficulty. The save/reset menu actions were centralized for better code reusability and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d08222c-703f-4b06-86bd-a3e63fb2deb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d08222c-703f-4b06-86bd-a3e63fb2deb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

